### PR TITLE
Generate config in --check mode

### DIFF
--- a/tasks/provision_dellos10.yaml
+++ b/tasks/provision_dellos10.yaml
@@ -14,3 +14,4 @@
    when: (ansible_network_os is defined and ansible_network_os == "dellos10") and ((dellos_cfg_generate | default('False')) | bool)
 #   notify: save config os10
    register: generate_output
+   check_mode: no

--- a/tasks/provision_dellos6.yaml
+++ b/tasks/provision_dellos6.yaml
@@ -14,3 +14,4 @@
    when: (ansible_network_os is defined and ansible_network_os == "dellos6") and ((dellos_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output
+   check_mode: no


### PR DESCRIPTION
This ensures that when using `dellos_cfg_generate` the config files are always generated. This allows exporting the generated config without having to do the actual provisioning.